### PR TITLE
Pipe wrapper

### DIFF
--- a/include/uvpp/loop.hpp
+++ b/include/uvpp/loop.hpp
@@ -75,11 +75,19 @@ public:
     }
 
     /**
-     *  Polls for new events without blocking.
+     *  Polls for new events once. Blocks if there are no pending events.
      */
     bool run_once()
     {
         return uv_run(m_uv_loop.get(), UV_RUN_ONCE) == 0;
+    }
+
+    /**
+     *  Polls for new events once without blocking.
+     */
+    bool run_nowait()
+    {
+        return uv_run(m_uv_loop.get(), UV_RUN_NOWAIT) == 0;
     }
 
     /**
@@ -133,11 +141,20 @@ inline int run()
 }
 
 /**
- *  Polls for new events without blocking for the default loop.
+ *  Polls for new events for the default loop once.
+ *  Blocks only if there are no pending events.
  */
 inline int run_once()
 {
     return uv_run(uv_default_loop(), UV_RUN_ONCE);
 }
-}
 
+/**
+ *  Polls for new events for the default loop once.
+ *  Non-blocking.
+ */
+inline int run_nowait()
+{
+    return uv_run(uv_default_loop(), UV_RUN_NOWAIT);
+}
+}

--- a/include/uvpp/pipe.hpp
+++ b/include/uvpp/pipe.hpp
@@ -1,0 +1,88 @@
+#pragma once
+
+#include "stream.hpp"
+#include "loop.hpp"
+
+namespace uvpp {
+class Pipe : public stream<uv_pipe_t>
+{
+public:
+    Pipe(const bool fd_pass = false):
+        stream()
+    {
+        uv_pipe_init(uv_default_loop(), get(), fd_pass ? 1 : 0);
+    }
+
+    Pipe(loop& l, const bool fd_pass = false):
+        stream()
+    {
+        uv_pipe_init(l.get(), get(), fd_pass ? 1 : 0);
+    }
+
+    bool bind(const std::string& name)
+    {
+        return uv_pipe_bind(get(), name.c_str()) == 0;
+    }
+
+    bool accept(stream& client)
+    {
+        return uv_accept(get(), client.handle<HANDLE_T>::template get<uv_stream_t>()) == 0;
+    }
+
+    void connect(const std::string& name, CallbackWithResult callback)
+    {
+        callbacks::store(get()->data, internal::uv_cid_connect, callback);
+        uv_pipe_connect(new uv_connect_t, get(), name.c_str(), [](uv_connect_t* req, int status)
+        {
+            std::unique_ptr<uv_connect_t> reqHolder(req);
+            callbacks::invoke<decltype(callback)>(req->handle->data, internal::uv_cid_connect, error(status));
+        });
+    }
+
+    bool getsockname(std::string& name)
+    {
+        std::vector<char> buf(100);
+        size_t buf_size = buf.size();
+        int r = uv_pipe_getsockname(get(), buf.data(), &buf_size);
+        if (r == UV_ENOBUFS) {
+            buf.resize(buf_size);
+            r = uv_pipe_getsockname(get(), buf.data(), &buf_size);
+        }
+
+        if (r == 0)
+        {
+            name = std::string(buf.data(), buf_size);
+            return true;
+        }
+        return false;
+    }
+
+    bool getpeername(std::string& name)
+    {
+        std::vector<char> buf(100);
+        size_t buf_size = buf.size();
+        int r = uv_pipe_getpeername(get(), buf.data(), &buf_size);
+        if (r == UV_ENOBUFS) {
+            buf.resize(buf_size);
+            r = uv_pipe_getpeername(get(), buf.data(), &buf_size);
+        }
+
+        if (r == 0)
+        {
+            name = std::string(buf.data(), buf_size);
+            return true;
+        }
+        return false;
+    }
+
+    int pending_count()
+    {
+        return uv_pipe_pending_count(get());
+    }
+
+    uv_handle_type pending_type()
+    {
+        return uv_pipe_pending_type(get());
+    }
+};
+}

--- a/include/uvpp/pipe.hpp
+++ b/include/uvpp/pipe.hpp
@@ -24,11 +24,6 @@ public:
         return uv_pipe_bind(get(), name.c_str()) == 0;
     }
 
-    bool accept(stream& client)
-    {
-        return uv_accept(get(), client.handle<HANDLE_T>::template get<uv_stream_t>()) == 0;
-    }
-
     void connect(const std::string& name, CallbackWithResult callback)
     {
         callbacks::store(get()->data, internal::uv_cid_connect, callback);

--- a/include/uvpp/uvpp.hpp
+++ b/include/uvpp/uvpp.hpp
@@ -7,3 +7,4 @@
 #include "poll.hpp"
 #include "fspoll.hpp"
 #include "fsevent.hpp"
+#include "pipe.hpp"

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -12,6 +12,7 @@
 #include "uvpp/tcp.hpp"
 #include "uvpp/idle.hpp"
 #include "uvpp/resolver.hpp"
+#include "uvpp/pipe.hpp"
 
 #include <memory>
 #include <limits>
@@ -35,12 +36,12 @@ int main()
         }
         std::cout << (ip4 ? "IP4" : "IP6") << ": " << addr << std::endl;
     });
-    
-    
-#if 0   
+
+
+#if 1
    uvpp::Tcp tcp(loop);
    if (!tcp.connect("127.0.0.1", 33013, [](auto e){
-       
+
        std::cout << "connected: " << e.str() << std::endl;
    }))
        std::cout << "error connect\n";
@@ -64,6 +65,6 @@ int main()
    });
 
    t.join();
-     
+
    return 0;
 }

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -12,7 +12,6 @@
 #include "uvpp/tcp.hpp"
 #include "uvpp/idle.hpp"
 #include "uvpp/resolver.hpp"
-#include "uvpp/pipe.hpp"
 
 #include <memory>
 #include <limits>
@@ -38,7 +37,7 @@ int main()
     });
 
 
-#if 1
+#if 0
    uvpp::Tcp tcp(loop);
    if (!tcp.connect("127.0.0.1", 33013, [](auto e){
 


### PR DESCRIPTION
This patch introduces libuv **uv_pipe_t** object wrapper and adds interface for non-blocking event polling (in case of zero events in loop) to **uvpp::loop** class.
